### PR TITLE
Fix gh action

### DIFF
--- a/.github/workflows/update-json.yml
+++ b/.github/workflows/update-json.yml
@@ -33,19 +33,13 @@ jobs:
         git add ./data/files.json
         git diff --cached --quiet || echo "has_changes=true" >> $GITHUB_ENV
 
+    # Step 5: Commit and push changes (if any)
     - name: Commit and push changes
+      if: env.has_changes == 'true'
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        git add ./data/files.json
         git commit -m "Update files.json after new CSV upload"
         git push
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    # Step 5: Deploy to GitHub Pages 
-    - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: . 


### PR DESCRIPTION
Fix false flags for action failures when there is nothing to commit
- action now looks for changes and will end with a successful status when there are none
- removed the deployment section since `update-gh-pages.yml` handles this on push to the `main` branch