### PR TITLE
Fix: Adjust header alignment to flex-start so both titles are left-aligned

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -10,7 +10,7 @@ body {
   header {
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: flex-start;
     width: fit-content;
   }
   


### PR DESCRIPTION
This is a slight stylistic adjustment.

This PR changes the subheader (H2) to be left-aligned after I noticed it was centered while the rest of the content is left-aligned.