### PR TITLE
remove lowercase text transformation for page titles

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -61,7 +61,6 @@ body {
     color: #9900FC;
     margin: 0;
     margin-top: 4rem;
-    text-transform: lowercase;
     font-size: 3rem;
     font-weight: 400;
   }


### PR DESCRIPTION
- Change titles from lowercase transformation to normal uppercase so it aligns with Hypha's branding