### PR TITLE
Add feature to make the announcement banner into a link

### DIFF
--- a/site/assets/script.js
+++ b/site/assets/script.js
@@ -16,6 +16,16 @@ async function loadAnnouncements() {
     // Update the banner with the announcement
     if (data.banner) {
       bannerContent.textContent = data.banner;
+      if (data.link) {
+        banner.style.cursor = 'pointer';
+        banner.classList.add('link-hover');
+        banner.onclick = () => {
+          window.location.href = data.link;
+        };
+      } else {
+        banner.style.cursor = 'default';
+        banner.onclick = null;
+      }
       banner.style.display = 'block';
     } else {
       banner.style.display = 'none';

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -115,6 +115,15 @@ body {
     display:none;
     width: fit-content;
   }
+
+  #banner a {
+    color: #9900FC;
+    text-decoration: none;
+  }
+
+  #banner.link-hover:hover {
+    border: 4px solid #9900FC;
+  }
   
   #controls {
     margin: 1rem 0;

--- a/site/data/announcements.json
+++ b/site/data/announcements.json
@@ -1,4 +1,5 @@
 {
-    "banner": "📋 Our feedback form is now live!"
+    "banner": "📋 Our feedback form is now live!",
+    "link": "/feedback/"
 }
   


### PR DESCRIPTION
- Allows to have the banner link to a specific page.

How does it work?

- Simply add a link to `site/data/announcements.json`

```
{
    "banner": "📋 Our feedback form is now live!",
    "link": "/feedback/"
}
```
  

The announcement banner is now a link!


No longer need a link?

- Remove the link 
- Make sure you also remove the comma on the banner line

```
{
    "banner": "📋 Our feedback form is now live!"
}
```
